### PR TITLE
Fix master build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
+dist: trusty
 language: scala
 
 scala:
-- 2.12.6
+- 2.12.8
 
 jdk:
 - oraclejdk8


### PR DESCRIPTION
Use trusty instead of xenial in order to keep building the project against java8
Bump scala version on travis yaml