### PR TITLE
fix: old version of sbt protobuf selects the bad protobuf compiler

### DIFF
--- a/project/protoc.sbt
+++ b/project/protoc.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.1")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.11"


### PR DESCRIPTION
Corrects:


```
[error] (bidswitch-json / protocExecutable) lmcoursier.internal.shaded.coursier.error.FetchError$DownloadingArtifacts: Error fetching artifacts:
[error] https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.13.0/protoc-3.13.0-osx-aarch_64.exe: not found: https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.13.0/protoc-3.13.0-osx-aarch_64.exe
```

On Apple M1 machines